### PR TITLE
Fix `Shale::Type::Boolean` in the tapioca compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/shale.rb
+++ b/lib/tapioca/dsl/compilers/shale.rb
@@ -138,6 +138,7 @@ module Tapioca
           ::Shale::Type::Integer  => Integer,
           ::Shale::Type::Time     => Time,
           ::Shale::Type::Date     => Date,
+          ::Shale::Type::Boolean  => Object,
         }.freeze,
         T::Hash[Class, Class],
       )


### PR DESCRIPTION
Added the missing `Shale::Type::Boolean` in the tapioca compiler.
